### PR TITLE
Adds last two processes (non-sex-chr)

### DIFF
--- a/bin/headerbuild.R
+++ b/bin/headerbuild.R
@@ -1,0 +1,93 @@
+#!/usr/bin/env Rscript
+
+### Description
+# This script is used in make_header process to generate new headers forannotated bcf files.
+# Current version is makeing aheader used for autosomes only.
+
+
+library(data.table)
+library(dplyr)
+library(magrittr)
+library(stringr);
+
+
+#Read in the header options
+toAdd <- fread("all_seen_flags.txt", header = F) %>% as_tibble() %>% 
+	filter(V1 != 'PASS');
+        starter <- '##FILTER=<ID=';
+        mid <- ',Description="';
+        end <- '.">'
+
+
+#Construct descriptions. We won't be all that descriptive for the filter field
+#more so for the info field. Just state failures for filter
+#Probably should add what the failing values are. Maybe only include these for the single instance onces
+#to save on space
+singlecases <- setNames(
+	as.list(c(
+	  'Fails depth, median depth < 10',
+          'Fails GQ, median GQ <15',
+          'Fails missingness, missingness > 0.05',
+          'Fails completeGTRatio, compelete sites <0.5',
+          'Fails AB ratio, AB ratio of (het sites passing binomial distribution with p-value < 0.01 / all het sites) < 0.25',
+          'Fails phwe_eur, site is out of HWE (<10e-6) for inferred unrelated inferred eur superpopulation'
+        )),
+        c('depth',
+          'GQ',
+          'missingness',
+          'completeGTRatio',
+          'ABratio',
+          'phwe_eur'
+	)
+   )
+
+singlecases <- paste0(starter, names(singlecases), mid, singlecases, end)
+#Now do all the other filter combinations
+	toAdd %<>% mutate(V2 = case_when(str_count(V1, ':') == 1 ~ str_replace(V1, ':',' and '),
+                               str_count(V1,':') > 1 ~ str_replace_all(V1,':',', '),
+                                TRUE ~ V1))
+        toAdd %<>% mutate(V2 = ifelse(str_count(V2,',') > 1, sub(".([^,]*)$", " and\\1", V2), V2))
+        toAdd %<>% mutate(V3 = paste0(starter,V1, mid, 'Fails ', V2, end))
+        #Now sort out the info
+        infostart <- '##INFO=<ID='
+        infomid <- ',Number=.,Type=Float,Description="'
+        infoend <- '">'
+    
+infos <- setNames(
+            as.list(c(
+	      'Median depth (taken from the DP FORMAT field) of all samples. Used for filter flag depth.',
+              'Median depth (taken from the DP FORMAT field) from samples with non-missing genotypes.',
+              'Median genotype quality(taken from the GQ FORMAT field) from samples with non-missing genotypes. Used for filter flag GQ.',
+              "Ratio of fully missing genotypes (GT = './.' and FORMAT/DP = 0)",
+              'The ratio of complete sites/total number of samples',
+              'For each het call, a binomial test is conducted for reads supporting the ref and alt alleles. AB ratio is the hets showing imbalance (p<0.01) divided by the total number of hets.',
+              'The number of Mendel Errors at this site, calculated from confirmed trios',
+              'HWE mid p-value in inferred unrelated inferred afr superpop.',
+              'HWE mid p-value in inferred unrelated inferred amr superpop.',
+              'HWE mid p-value in inferred unrelated inferred eas superpop.',
+              'HWE mid p-value in inferred unrelated inferred eur superpop.',
+              'HWE mid p-value in inferred unrelated inferred sas superpop.'
+            )),
+            c("medianDepthAll",
+              "medianDepthNonMiss",
+              "medianGQ",
+              "missingness",
+              "completeGTRatio",
+              "ABratio",
+              "MendelSite",
+              "phwe_afr",
+              "phwe_amr",
+              "phwe_eas",
+              "phwe_eur",
+              "phwe_sas"
+             )
+    )
+
+
+#Now build this info full string
+infosout <- paste0(infostart, names(infos), infomid, infos, infoend )
+
+#Now print this out to file, and add it to the rest of the header
+names(singlecases <- NULL)
+d <- c(singlecases, toAdd$V3, infosout) %>% unlist() %>% as.data.frame() 
+fwrite(d, 'additional_header.txt', quote = F, col.names = F)

--- a/bin/headerbuild.R
+++ b/bin/headerbuild.R
@@ -1,8 +1,8 @@
 #!/usr/bin/env Rscript
 
 ### Description
-# This script is used in make_header process to generate new headers forannotated bcf files.
-# Current version is makeing aheader used for autosomes only.
+# This script is used in make_header process to generate new headers for annotated bcf files.
+# Current version is making a header used for autosomes only.
 
 
 library(data.table)

--- a/conf/aws.config
+++ b/conf/aws.config
@@ -56,8 +56,5 @@ params {
   N_samples_suffix = '_N_samples.txt'
   AC_counts_dir = 'AC_counts'
   AC_counts_suffix = '_AC'
-  annotate_dir = 'Annotation'
-  stats_dir = 'Summary_stats'
-  all_flags_suffix = '_all_flags.txt'
 
 }

--- a/conf/aws.config
+++ b/conf/aws.config
@@ -56,5 +56,8 @@ params {
   N_samples_suffix = '_N_samples.txt'
   AC_counts_dir = 'AC_counts'
   AC_counts_suffix = '_AC'
+  annotate_dir = 'Annotation'
+  stats_dir = 'Summary_stats'
+  all_flags_suffix = '_all_flags.txt'
 
 }

--- a/conf/test.config
+++ b/conf/test.config
@@ -60,9 +60,5 @@ params {
   N_samples_suffix = '_N_samples.txt'
   AC_counts_dir = 'AC_counts'
   AC_counts_suffix = '_AC'
-  annotate_dir = 'Annotation'
-  stats_dir = 'Summary_stats'
-  all_flags_suffix = '_all_flags.txt'
-
 
 }

--- a/conf/test.config
+++ b/conf/test.config
@@ -60,7 +60,9 @@ params {
   N_samples_suffix = '_N_samples.txt'
   AC_counts_dir = 'AC_counts'
   AC_counts_suffix = '_AC'
-
+  annotate_dir = 'Annotation'
+  stats_dir = 'Summary_stats'
+  all_flags_suffix = '_all_flags.txt'
 
 
 }

--- a/main.nf
+++ b/main.nf
@@ -139,7 +139,7 @@ if (!params.input) exit 1, "The list of input bcf/vcf files was not provided. \n
 if (!params.predicted_ancestries) exit 1, "The participants' predicted ancestry file was not specified. \nPlease provide it with --predicted_ancestries [file] option. \nUse --help option for more information."
 
 // Check if user provided input csv file containing paths to bcf files and their indexes
-if (!params.unrelated_list) exit 1, "The list of unrelated participants was not specified. \nPlease provide it with --predicted_ancestries [file] option. \nUse --help option for more information."
+if (!params.unrelated_list) exit 1, "The list of unrelated participants was not specified. \nPlease provide it with --unrelated_list [file] option. \nUse --help option for more information."
 
 // Check if user provided SiteQC results directory
 if (!params.siteqc_results_dir) exit 1, "The SiteQC results folder was not specified. \nPlease provide it with --siteqc_results_dir [dir] option. \nUse --help option for more information."

--- a/main.nf
+++ b/main.nf
@@ -320,7 +320,7 @@ process end_aggregate_annotation {
           file(AC_counts) from ch_joined_files_to_aggregate
 
     output:
-    file "BCFtools_site_metrics_*.txt" into ch_end_aggr_annotation
+    tuple file("BCFtools_site_metrics_*.txt.gz"), file("BCFtools_site_metrics_*.txt.gz.tbi") into ch_end_aggr_annotation
     file "Summary_stats/*_all_flags.txt" into ch_summary_stats
 
     script:
@@ -345,6 +345,9 @@ process end_aggregate_annotation {
     '.' \
     ${params.king} \
     ${params.aggregate_final}
+
+    bgzip -f BCFtools_site_metrics_${region}.txt
+    tabix -f -s1 -b2 -e2 BCFtools_site_metrics_${region}.txt.gz
     """
 }
 


### PR DESCRIPTION
## Main
- [x] Adds `make_header` process + its R script
- [x] Adds final `annotate_bcfs` process

## Note:
Pipeline at the state of this PR is prepared to process bcf files from autosomes only. Initial source code appeared to be not complete and missed the parts of processing sex and M chromosomes.

An entire separate sub-workflow should be prepared for processing X chromosomes, and one process should be added specifically for Y and M chromosomes. These changes have to be applied for both **Annotate** pipeline and its predecessor - **SiteQC** pipeline. Future PRs will address that issue.

## To test
### Successful CloudOS run:
https://cloudos.lifebit.ai/public/jobs/5fa1686c61aba10112123a29
![image](https://user-images.githubusercontent.com/64809705/98001841-5038eb80-1df6-11eb-8f95-837831b2eb98.png)

### Locally
```
git clone https://github.com/lifebit-ai/annotate
cd annotate
git checkout vlad-dev-3
nextflow run . -profile -test
```
(will take 2-3 min)
![image](https://user-images.githubusercontent.com/64809705/97993767-2fb86380-1ded-11eb-8ad8-bee213a8c3e7.png)

## DAG
![image](https://user-images.githubusercontent.com/64809705/97993890-5a0a2100-1ded-11eb-8640-2589175845ed.png)
